### PR TITLE
Removed by ref method call in decode()

### DIFF
--- a/src/CBOR/CBOREncoder.php
+++ b/src/CBOR/CBOREncoder.php
@@ -98,8 +98,10 @@ class CBOREncoder
      */
     public static function decode(&$var){
         $out = null;
+        
         //get initial byte
-        $header_byte = array_shift(unpack("C*", substr($var, 0, 1)));
+        $unpacked = unpack("C*", substr($var, 0, 1));
+        $header_byte = array_shift($unpacked);
 
         //unpack major type
         $major_type = $header_byte & self::ADDITIONAL_WIPE;


### PR DESCRIPTION
A by ref call on a method throws an error under strict settings. `$header_byte = array_shift(unpack("C*", substr($var, 0, 1)));` should be changed to:

``` php
$unpacked = unpack("C*", substr($var, 0, 1));
$header_byte = array_shift($unpacked);
```

This ensures that a variable is called by reference instead of a method. You can read more about this [here](http://stackoverflow.com/questions/9848295/strict-standards-only-variables-should-be-passed-by-reference-error) and [here](http://stackoverflow.com/questions/2354609/strict-standards-only-variables-should-be-passed-by-reference).
