### PR TITLE
Changed private function bigint_unpack($big_int) to static private fu…

### DIFF
--- a/src/CBOR/CBOREncoder.php
+++ b/src/CBOR/CBOREncoder.php
@@ -422,7 +422,7 @@ class CBOREncoder
      * @param $big_int
      * @return string
      */
-    private function bigint_unpack($big_int)
+    private static function bigint_unpack($big_int)
     {
         list($higher, $lower) = array_values(unpack("N2", $big_int));
         return $higher << 32 | $lower;


### PR DESCRIPTION
bigint_unpack() is called static but not declared static thus results in error in current PHP.
This is my first attempt of a pull request, so let's hope it works!